### PR TITLE
Prices API proto files

### DIFF
--- a/bolt/assets/v1/assets.proto
+++ b/bolt/assets/v1/assets.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package bolt.assets.v1;
+
+// Pair: The pair for which the price is being updated. e.g. ATOM/USDT
+message Pair {
+  // base: The base asset of the pair. e.g. ATOM
+  string base = 1;
+  // quote: The quote asset of the pair. e.g. USDT
+  string quote = 2;
+}

--- a/bolt/outpost/centralized_oracle/v1/centralized_oracle.proto
+++ b/bolt/outpost/centralized_oracle/v1/centralized_oracle.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package bolt.outpost.centralized_oracle.v1;
 
+import "bolt/assets/v1/assets.proto";
 import "google/protobuf/timestamp.proto";
 
 // Service 1: OracleService
@@ -35,17 +36,9 @@ message InfoResponse {
 // PriceUpdate: Price update for a given pair
 message PriceUpdate {
   // pair: The pair for which the price is being updated. e.g. ATOM/USDT
-  Pair pair = 1;
+  bolt.assets.v1.Pair pair = 1;
   // price: The price of the pair. e.g. 10.0
   string price = 2;
   // timestamp: The timestamp of the price update. e.g. 2023-10-01T00:00:00Z
   google.protobuf.Timestamp timestamp = 3;
-}
-
-// Pair: The pair for which the price is being updated. e.g. ATOM/USDT
-message Pair {
-  // base: The base asset of the pair. e.g. ATOM
-  string base = 1;
-  // quote: The quote asset of the pair. e.g. USDT
-  string quote = 2;
 }

--- a/bolt/prices/v1/prices.proto
+++ b/bolt/prices/v1/prices.proto
@@ -1,0 +1,106 @@
+syntax = "proto3";
+
+package bolt.prices.v1;
+
+import "bolt/assets/v1/assets.proto";
+import "google/protobuf/timestamp.proto";
+
+// PricesService: Prices venue service....
+service PricesService {
+  // Endpoint to fetch the price of the pair.
+  rpc GetPrice(GetPriceRequest) returns (GetPriceResponse);
+
+  // Endpoint to fetch multiple pairs prices in batch.
+  rpc GetPrices(GetPricesRequest) returns (GetPricesResponse);
+
+  // Endpoint to subscribe on the price changes.
+  rpc StreamPrice(StreamPriceRequest) returns (stream StreamPriceResponse);
+
+  // Endpoint to subscribe on mutiple pairs price changes.
+  rpc StreamPrices(StreamPricesRequest) returns (stream StreamPricesResponse);
+
+  // Endpoint to query for price venue information.
+  rpc GetPriceVenueInfo(GetPriceVenueInfoRequest) returns (GetPriceVenueInfoResponse);
+
+  // Endpoint to query for available price pairs.
+  rpc GetPricePairs(GetPricePairsRequest) returns (GetPricePairsResponse);
+}
+
+// GetPriceRequest: Request fetching the pair price.
+message GetPriceRequest {
+  // pair: The specific market pair. e.g. ATOM/USDT
+  bolt.assets.v1.Pair pair = 1;
+}
+
+// GetPriceResponse: Response to GetPriceRequest.
+message GetPriceResponse {
+  // pair: The pair associated with the price. e.g. ATOM/USDT
+  bolt.assets.v1.Pair pair = 1;
+  // price: The price of the pair. e.g. 10.0
+  string price = 2;
+  // last_updated: The timestamp when the price was updated for the last time, optional.
+  google.protobuf.Timestamp last_updated = 3;
+}
+
+// GetPricesRequest: Request fetching multiple pairs prices.
+message GetPricesRequest {
+  // pairs: List of pairs to fetch prices for. If empty should return all the prices.
+  repeated bolt.assets.v1.Pair pairs = 1;
+}
+
+// GetPricesResponse: Response to GetPricesRequest.
+message GetPricesResponse {
+  // prices: List of prices information for requested pairs. Every item is a
+  // GetPriceResponse as it would be returned if price was requested individualy
+  // with GetPrice.
+  repeated GetPriceResponse prices = 1;
+}
+
+// StreamPriceRequest: Subscribes to price changes.
+message StreamPriceRequest {
+  // pair: The specific market pair. e.g. ATOM/USDT
+  bolt.assets.v1.Pair pair = 1;
+}
+
+// StreamPriceResponse: Response to StreamPriceRequest.
+message StreamPriceResponse {
+  // pair: The pair associated with the price. e.g. ATOM/USDT
+  bolt.assets.v1.Pair pair = 1;
+  // price: The price of the pair. e.g. 10.0
+  string price = 2;
+  // last_updated: The timestamp when the price was updated for the last time, optional.
+  google.protobuf.Timestamp last_updated = 3;
+}
+
+// StreamPricesRequest: Subscribes to price changes on multiple pairs.
+message StreamPricesRequest {
+  // pairs: List of pairs to fetch prices for. If empty should return all the prices.
+  repeated bolt.assets.v1.Pair pairs = 1;
+}
+
+// StreamPricesResponse: Response to StreamPricesRequest.
+message StreamPricesResponse {
+  // updates: List of price updates.
+  repeated StreamPriceResponse updates = 1;
+}
+
+// GetPriceVenueInfoRequest: Queries for the price venue information.
+message GetPriceVenueInfoRequest {}
+
+// GetPriceVenueInfoResponse: Response to GetPriceVenueInfoRequest.
+message GetPriceVenueInfoResponse {
+  // identifier: Price venue identifier. e. g. Bybit, Binance, CoinGecko
+  string identifier = 1;
+  // network_identifier: Blockchain network identifier, or empty if the price venue
+  // is not a blockchain.
+  string network_identifier = 2;
+}
+
+// GetPricePairsRequest: Queries for the available price pairs.
+message GetPricePairsRequest {}
+
+// GetPricePairsResponse: Response to GetPricePairsRequest.
+message GetPricePairsResponse {
+  // pairs: List of price pairs supported by this price venue.
+  repeated bolt.assets.v1.Pair pairs = 1;
+}

--- a/bolt/prices/v1/prices.proto
+++ b/bolt/prices/v1/prices.proto
@@ -13,9 +13,6 @@ service PricesService {
   // Endpoint to fetch multiple pairs prices in batch.
   rpc GetPrices(GetPricesRequest) returns (GetPricesResponse);
 
-  // Endpoint to subscribe on the price changes.
-  rpc StreamPrice(StreamPriceRequest) returns (stream StreamPriceResponse);
-
   // Endpoint to subscribe on mutiple pairs price changes.
   rpc StreamPrices(StreamPricesRequest) returns (stream StreamPricesResponse);
 

--- a/bolt/prices/v1/prices.proto
+++ b/bolt/prices/v1/prices.proto
@@ -36,7 +36,7 @@ message GetPriceRequest {
 message GetPriceResponse {
   // pair: The pair associated with the price. e.g. ATOM/USDT
   bolt.assets.v1.Pair pair = 1;
-  // price: The price of the pair. e.g. 10.0
+  // price: The price of the pair, in rational values. e.g. 1250/13
   string price = 2;
   // last_updated: The timestamp when the price was updated for the last time, optional.
   google.protobuf.Timestamp last_updated = 3;
@@ -66,7 +66,7 @@ message StreamPriceRequest {
 message StreamPriceResponse {
   // pair: The pair associated with the price. e.g. ATOM/USDT
   bolt.assets.v1.Pair pair = 1;
-  // price: The price of the pair. e.g. 10.0
+  // price: The price of the pair, in rational values. e.g. 1250/13
   string price = 2;
   // last_updated: The timestamp when the price was updated for the last time, optional.
   google.protobuf.Timestamp last_updated = 3;

--- a/examples/buf.gen.go.yaml
+++ b/examples/buf.gen.go.yaml
@@ -6,18 +6,24 @@ plugins:
     out: ./go
     opt:
       - paths=source_relative
+      - Mbolt/assets/v1/assets.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/assets/v1
       - Mbolt/outpost/centralized_oracle/v1/centralized_oracle.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/outpost/centralized_oracle/v1
       - Mbolt/outpost/settlement/v1/settlement.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/outpost/settlement/v1
+      - Mbolt/prices/v1/prices.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/prices/v1
 
   # Generate Go gRPC code
   - remote: buf.build/grpc/go:v1.2.0
     out: ./go
     opt:
       - paths=source_relative
+      - Mbolt/assets/v1/assets.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/assets/v1
       - Mbolt/outpost/centralized_oracle/v1/centralized_oracle.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/outpost/centralized_oracle/v1
       - Mbolt/outpost/settlement/v1/settlement.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/outpost/settlement/v1
+      - Mbolt/prices/v1/prices.proto=github.com/phi-labs-ltd/bolt-proto/go/bolt/prices/v1
       - require_unimplemented_servers=false
 
 inputs:
+  - proto_file: ../bolt/assets/v1/assets.proto
   - proto_file: ../bolt/outpost/centralized_oracle/v1/centralized_oracle.proto
   - proto_file: ../bolt/outpost/settlement/v1/settlement.proto
+  - proto_file: ../bolt/prices/v1/prices.proto

--- a/examples/buf.gen.rust.yaml
+++ b/examples/buf.gen.rust.yaml
@@ -17,5 +17,7 @@ plugins:
       - no_client=false
 
 inputs:
+  - proto_file: ../bolt/assets/v1/assets.proto
   - proto_file: ../bolt/outpost/centralized_oracle/v1/centralized_oracle.proto
   - proto_file: ../bolt/outpost/settlement/v1/settlement.proto
+  - proto_file: ../bolt/prices/v1/prices.proto


### PR DESCRIPTION
Closes BOLT-62

In addition to proto files itself I extracted the `Pair` type to its own proto file as it seems to be done in the original setup. Also I'm somewhat concerned about the `StreamPriceResponse` and `StreamPriceResponses` (also probably equivalent `*Request` types) - I am not sure why are they needed instead of just reusing `GetPrice*` types here - it is supposed to be the same forever, except is one-time-shot, and the other is the streaming API. I'd eventually merge those, but for now I intentionally keep the original structure.