### PR TITLE
Return transaction id when posting prices to the oracle

### DIFF
--- a/bolt/outpost/centralized_oracle/v1/centralized_oracle.proto
+++ b/bolt/outpost/centralized_oracle/v1/centralized_oracle.proto
@@ -20,7 +20,10 @@ message PostPricesRequest {
 }
 
 // PostPricesResponse: Response to the PostPricesRequest. Doesn't respond anything on success.
-message PostPricesResponse {}
+message PostPricesResponse {
+  // tx_id: The hash of the transaction.
+  string tx_id = 1;
+}
 
 // InfoRequest: Request to get information about the oracle. Should be invoked by pricefeeder
 message InfoRequest {}


### PR DESCRIPTION
Currently there is no way to know if the update price action was successful, so this would be useful.