### PR TITLE
feat: adding minimal CEX service

### DIFF
--- a/bolt/cex/v2/cex.proto
+++ b/bolt/cex/v2/cex.proto
@@ -43,7 +43,7 @@ message InfoRequest {}
 message InfoResponse {
   // chain_id: The chain id of the chain the CEX service is running on. e.g. archway-1
   string chain_id = 1;
-  // whoami: The address of the signer who will be submitting sending and receiving funds from the chain
+  // whoami: The address of the signer who will be submitting transactions for sending and receiving funds from the chain
   string whoami = 2;
 }
 


### PR DESCRIPTION
Previous CEX service was built for a more comprehensive functionality, but this might not always be needed. When specific assets by MM are not hedged etc. This will allow only deposit and withdraw operations so rebalancing can occur.