### PR TITLE
feat: Add price field to Trade message in settlement.proto

### DIFF
--- a/bolt/outpost/settlement/v1/settlement.proto
+++ b/bolt/outpost/settlement/v1/settlement.proto
@@ -147,6 +147,8 @@ message Trade {
   bolt.assets.v1.Balance lp_fee = 9;
   // timestamp: Timestamp of the trade in nanoseconds.
   google.protobuf.Timestamp timestamp = 10;
+  // price: Price used by the pool to execute the trade, in rational values e.g. 5/3
+  string price = 11;
 }
 
 // Pool: Description of the single liquidity pool.


### PR DESCRIPTION
Introduces a new 'price' field to the Trade message, representing the price used by the pool to execute the trade as a rational value (e.g., 5/3). This provides more detailed trade information for consumers of the API.