### PR TITLE
feat: Add cex_order_type to CloseHedgingRequest

### DIFF
--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -277,6 +277,8 @@ message CloseHedgingRequest {
   optional google.protobuf.Timestamp finished_at = 12;
   // ladder_summary: Summary of the timeout ladder execution for this hedge.
   optional string ladder_summary = 13;
+  // cex_order_type: The actual CEX order side (Buy/Sell) at execution time.
+  bolt.outpost.settlement.v2.SwapType cex_order_type = 14;
 }
 
 // CloseHedgingResponse: Result of a CloseHedging call.


### PR DESCRIPTION
Introduce an optional cex_order_type field (tag 14) to CloseHedgingRequest to record the actual CEX order side (Buy/Sell) at execution time. The field uses bolt.outpost.settlement.v2.SwapType and will aid in reconciliation, auditing, and linking hedging results to executed CEX orders.