### PR TITLE
feat: Add Public/Private MarketLedger gRPC services

### DIFF
--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -39,6 +39,36 @@ service MarketLedgerService {
   rpc GetMarketLedgerById(GetMarketLedgerByIdRequest) returns (GetMarketLedgerByIdResponse);
 }
 
+// The PublicMarketLedgerService exposes the same RPCs as MarketLedgerService but with restricted endpoints for external consumption.
+service PublicMarketLedgerService {
+  // Streams the running ledger as the initial snapshot, then live updates per block.
+  // In-flight hedges are included via the hedge_orders field (cex_order_status=open).
+  // field_mask paths: "swaps", "hedge_orders" opt in to those fields.
+  rpc SubscribeMarketLedger(SubscribeMarketLedgerRequest) returns (stream SubscribeMarketLedgerResponse);
+  // Returns all configs for the given asset (both Long and Short directions).
+  rpc GetEngineConfigsForAsset(GetEngineConfigsForAssetRequest) returns (GetEngineConfigsForAssetResponse);
+  // Returns all engine configs across all assets and directions.
+  rpc GetEngineConfigs(GetEngineConfigsRequest) returns (GetEngineConfigsResponse);
+  // Returns the current Running ledger for the given asset, or absent if none exists.
+  rpc GetOpenMarketLedger(GetOpenMarketLedgerRequest) returns (GetOpenMarketLedgerResponse);
+  // Returns all Running ledgers across every asset, ordered by asset name.
+  rpc GetOpenMarketLedgers(GetOpenMarketLedgersRequest) returns (GetOpenMarketLedgersResponse);
+  // Returns the ledger with the given id.
+  rpc GetMarketLedgerById(GetMarketLedgerByIdRequest) returns (GetMarketLedgerByIdResponse);
+}
+
+// The PrivateMarketLedgerService exposes RPCs for internal use by the MM.
+service PrivateMarketLedgerService {
+  // Subtracts hedged delta from running ledger, creates in_progress row + hedge order.
+  // Response includes an optional MarketLedgerEvent (present if adjusted delta != 0).
+  rpc StartHedging(StartHedgingRequest) returns (StartHedgingResponse);
+  // Closes a specific hedge order with fill details. Transitions in_progress → closed.
+  // For cancel/error/partial: adds delta back to running ledger, returns updated event.
+  rpc CloseHedging(CloseHedgingRequest) returns (CloseHedgingResponse);
+  // Inserts or replaces the engine config for a single (asset, direction) pair.
+  rpc UpsertEngineConfig(UpsertEngineConfigRequest) returns (UpsertEngineConfigResponse);
+}
+
 // ── Shared messages ──────────────────────────────────────────────────────────
 
 // TimeoutStep: One rung of the hedge timeout ladder.

--- a/buf.yaml
+++ b/buf.yaml
@@ -6,6 +6,8 @@ lint:
     - STANDARD
     - COMMENTS
     - FILE_LOWER_SNAKE_CASE
+  ignore:
+    - bolt/outpost/market_ledger/v1/market_ledger.proto # Temporary as we transition to splitting the service, else we get error that same Request message is used in multiple services
 breaking:
   use:
     - FILE


### PR DESCRIPTION
Split the service so the private one can be protected by TLS while the public one is accessible by all components