### PR TITLE
feat: add total_base_liquidity to BalanceUpdate v2

### DIFF
--- a/bolt/outpost/settlement/v2/settlement.proto
+++ b/bolt/outpost/settlement/v2/settlement.proto
@@ -277,6 +277,8 @@ message BalanceUpdate {
   string shares_updated = 6;
   // total_lp_shares: Total amount of LP shares in the pool after the update.
   string total_lp_shares = 7;
+  // total_base_liquidity: Total BASE liquidity in the pool after the update.
+  bolt.assets.v1.Balance total_base_liquidity = 8;
 }
 
 // BalanceUpdateType: Enum representing the type of balance update.


### PR DESCRIPTION
## Summary
- Adds `total_base_liquidity` (field 8) to the v2 `BalanceUpdate` proto message
- Provides the post-event total BASE liquidity in the pool (human-readable decimal)
- Required by the ActiveRebalancer in bolt-mm for stream-based threshold detection

## Context
Part of BOLT-1788: ActiveRebalancer implementation. See `bolt-mm/docs/specs/2026-04-14-active-rebalancer-design.md` for full design spec.