### PR TITLE
chore:  move spread_bps to timeout step

### DIFF
--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -83,9 +83,6 @@ message TimeoutStep {
 
 // EngineConfig: Hedging parameters for a single (asset, direction) pair.
 message EngineConfig {
-  // spread_bps (field 6) removed — moved to per-rung TimeoutStep.spread_bps.
-  reserved 6;
-  reserved "spread_bps";
   // asset: Base asset symbol (e.g. "SUI").
   string asset = 1;
   // direction: Position direction this config governs (Long or Short).

--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -77,10 +77,15 @@ message TimeoutStep {
   google.protobuf.Duration delay = 1;
   // strategy: Execution strategy to use at this timeout rung.
   ExecutionStrategy strategy = 2;
+  // spread_bps: Optional spread in basis points applied to this rung's limit price.
+  optional uint32 spread_bps = 3;
 }
 
 // EngineConfig: Hedging parameters for a single (asset, direction) pair.
 message EngineConfig {
+  // spread_bps (field 6) removed — moved to per-rung TimeoutStep.spread_bps.
+  reserved 6;
+  reserved "spread_bps";
   // asset: Base asset symbol (e.g. "SUI").
   string asset = 1;
   // direction: Position direction this config governs (Long or Short).
@@ -91,8 +96,6 @@ message EngineConfig {
   bolt.common.numeric.v1.Fraction hard_cap = 4;
   // timeout_ladder: Ordered list of timeout rungs with escalating strategies.
   repeated TimeoutStep timeout_ladder = 5;
-  // spread_bps: Optional spread in basis points applied to limit price.
-  optional uint32 spread_bps = 6;
 }
 
 // SwapEvent: A single swap event ingested from the on-chain pool.


### PR DESCRIPTION
spread_bps will now be configured on a per rung level for greater flexibility.