### PR TITLE
feat: Add prices v1 Oracle proto and service

### DIFF
--- a/bolt/prices/v1/oracle.proto
+++ b/bolt/prices/v1/oracle.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package bolt.prices.v1;
+
+import "bolt/assets/v1/assets.proto";
+import "bolt/common/numeric/v1/numeric.proto";
+import "google/protobuf/timestamp.proto";
+
+// OracleService: Oracle service for subscribing to prices being posted by Pricefeeder.
+service OracleService {
+  // SubscribePrices: Subscribes to price changes for the specified pairs. If no pairs are specified, it subscribes to all price changes.
+  rpc SubscribePrices(SubscribePricesRequest) returns (stream SubscribePricesResponse);
+}
+
+// SubscribePricesRequest: Request for subscribing to price changes.
+message SubscribePricesRequest {
+  // pairs: List of pairs to subscribe to. If empty, subscribes to all price changes.
+  repeated bolt.assets.v1.Pair pairs = 1;
+}
+
+// SubscribePricesResponse: Response for subscribing to price changes.
+message SubscribePricesResponse {
+  // pair: The pair for which the price is being updated.
+  bolt.assets.v1.Pair pair = 1;
+  // generated_at: The timestamp of the price generation.
+  google.protobuf.Timestamp generated_at = 2;
+  // posted_at: The timestamp of the price posting. This field is optional and may be null if the price has never been posted but intermediately calculated.
+  optional google.protobuf.Timestamp posted_at = 3;
+  // price: The price for the asset pair.
+  bolt.common.numeric.v1.Fraction price = 4;
+  // metadata: Additional metadata specific to the price calculation
+  oneof metadata {
+    // avo_metadata: Metadata specific to AVOMetadata.
+    AVOMetadata avo_metadata = 5;
+  }
+}
+
+// AVOMetadata: Metadata specific to AVOMetadata price calculation.
+message AVOMetadata {
+  // pair: The pair for which the price is being updated.
+  bolt.assets.v1.Pair pair = 1;
+  // bid: The bid price for the asset pair.
+  bolt.common.numeric.v1.Fraction bid = 2;
+  // ask: The ask price for the asset pair.
+  bolt.common.numeric.v1.Fraction ask = 3;
+  // spread: The spread between the bid and ask prices for the asset pair.
+  bolt.common.numeric.v1.Fraction spread = 4;
+}

--- a/bolt/prices/v1/quoting.proto
+++ b/bolt/prices/v1/quoting.proto
@@ -6,20 +6,20 @@ import "bolt/assets/v1/assets.proto";
 import "bolt/common/numeric/v1/numeric.proto";
 import "google/protobuf/timestamp.proto";
 
-// OracleService: Oracle service for subscribing to prices being posted by Pricefeeder.
-service OracleService {
-  // SubscribePrices: Subscribes to price changes for the specified pairs. If no pairs are specified, it subscribes to all price changes.
-  rpc SubscribePrices(SubscribePricesRequest) returns (stream SubscribePricesResponse);
+// QuotingService: QuotingService for subscribing to prices being posted by Pricefeeder.
+service QuotingService {
+  // SubscribePriceQuotes: Subscribes to price changes for the specified pairs. If no pairs are specified, it subscribes to all price changes.
+  rpc SubscribePriceQuotes(SubscribePriceQuotesRequest) returns (stream SubscribePriceQuotesResponse);
 }
 
-// SubscribePricesRequest: Request for subscribing to price changes.
-message SubscribePricesRequest {
+// SubscribePriceQuotesRequest: Request for subscribing to price changes.
+message SubscribePriceQuotesRequest {
   // pairs: List of pairs to subscribe to. If empty, subscribes to all price changes.
   repeated bolt.assets.v1.Pair pairs = 1;
 }
 
-// SubscribePricesResponse: Response for subscribing to price changes.
-message SubscribePricesResponse {
+// SubscribePriceQuotesResponse: Response for subscribing to price changes.
+message SubscribePriceQuotesResponse {
   // pair: The pair for which the price is being updated.
   bolt.assets.v1.Pair pair = 1;
   // generated_at: The timestamp of the price generation.


### PR DESCRIPTION
Introduce bolt/prices/v1/oracle.proto defining an OracleService for streaming price updates (SubscribePrices). Adds SubscribePricesRequest (pairs filter) and SubscribePricesResponse (pair, generated_at, optional posted_at, price as Fraction, and a metadata oneof). Includes AVOMetadata (pair, bid, ask, spread). Imports bolt assets, numeric types and google timestamp. This provides the initial proto surface for Pricefeeder price subscriptions.