### PR TITLE
feat: Add PARTNER_CETUS enum to partners.proto

### DIFF
--- a/bolt/common/partners/v1/partners.proto
+++ b/bolt/common/partners/v1/partners.proto
@@ -14,4 +14,6 @@ enum Partner {
   PARTNER_FLOWX = 3;
   // Aftermath partner integration
   PARTNER_AFTERMATH = 4;
+  // Cetus partner integration
+  PARTNER_CETUS = 5;
 }


### PR DESCRIPTION
Introduce PARTNER_CETUS (value 5) to the Partner enum in bolt/common/partners/v1/partners.proto to represent the Cetus partner integration. A brief comment describing the integration was also added; no other changes made.