### PR TITLE
feat: Add expiry timestamp to price responses

### DIFF
--- a/bolt/prices/v1/prices.proto
+++ b/bolt/prices/v1/prices.proto
@@ -37,6 +37,8 @@ message GetPriceResponse {
   string price = 2;
   // last_updated: The timestamp when the price was updated for the last time, optional.
   google.protobuf.Timestamp last_updated = 3;
+  // expiry: The timestamp when the price expires.
+  google.protobuf.Timestamp expiry = 4;
 }
 
 // GetPricesRequest: Request fetching multiple pairs prices.
@@ -67,6 +69,8 @@ message StreamPriceResponse {
   string price = 2;
   // last_updated: The timestamp when the price was updated for the last time, optional.
   google.protobuf.Timestamp last_updated = 3;
+  // expiry: The timestamp when the price expires.
+  google.protobuf.Timestamp expiry = 4;
 }
 
 // StreamPricesRequest: Subscribes to price changes on multiple pairs.


### PR DESCRIPTION
Add an expiry field to price response messages in bolt/prices/v1/prices.proto. Introduces `google.protobuf.Timestamp expiry = 4` (with comment) to both GetPriceResponse and StreamPriceResponse so callers can know when a reported price expires. This is an optional, backward-compatible protobuf addition.