### PR TITLE
chore: migrate CI workflows to self-hosted runners

### DIFF
--- a/.github/workflows/buf-registry.yaml
+++ b/.github/workflows/buf-registry.yaml
@@ -11,7 +11,7 @@ jobs:
   publish:
     if: ${{ !github.event.release.prerelease }}
     name: Publish to Buf Schema Registry
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v1

--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 jobs:
   buf:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v1


### PR DESCRIPTION
Switch buf and buf-registry workflows from ubuntu-latest to self-hosted runners.