### PR TITLE
feat: reshape CexOrderRecord to per-rung snapshot [BOLT-1833]

### DIFF
--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -427,6 +427,10 @@ message CexOrderRecord {
   // response_msg: Raw CEX response payload (JSON-serialized) at this rung for
   // forensics. Service stores this directly into a JSONB column.
   optional string response_msg = 16;
+  // ladder_summary: Summary of the timeout-ladder execution captured in this
+  // snapshot. Distinct from `response_msg` (raw CEX payload): this is the
+  // MM-side rung-execution summary.
+  optional string ladder_summary = 17;
 }
 
 // CloseHedgingResponse: Result of a CloseHedging call.

--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -427,9 +427,7 @@ message CexOrderRecord {
   // response_msg: Raw CEX response payload (JSON-serialized) at this rung for
   // forensics. Service stores this directly into a JSONB column.
   optional string response_msg = 16;
-  // ladder_summary: Summary of the timeout-ladder execution captured in this
-  // snapshot. Distinct from `response_msg` (raw CEX payload): this is the
-  // MM-side rung-execution summary.
+  // ladder_summary: Summary of the timeout ladder execution for this hedge.
   optional string ladder_summary = 17;
 }
 

--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -368,69 +368,65 @@ message CloseHedgingRequest {
   // cex_order_records: The cex order records that the order was decomposed into. Preferred over the
   // deprecated flat fill fields above, which describe only the aggregate.
   repeated CexOrderRecord cex_order_records = 15;
+  // instrument_name: CEX instrument used for the hedge (e.g. "SUI-USDC").
+  // MM-supplied. The service has no record of it before close_hedging — this
+  // is the canonical hedge-level value (one instrument per hedge), shared
+  // across every CexOrderRecord in `cex_order_records`.
+  string instrument_name = 16;
 }
 
 // CexOrderRecord: Snapshot of a CEX order at one rung of its execution. One row
-// is emitted per (bucket, rung) per CEX order placed in the hedge — at each rung
+// is emitted per rung per CEX order placed in the hedge — at each rung
 // transition (entering a new rung) and at the terminal moment (filled / cancelled
-// / errored). Stable fields (bucket_idx, rung_idx, client_order_id, cex_order_id,
-// instrument_name, cex_order_kind, cex_order_type) repeat across snapshots of the
-// same order; snapshot fields (fills, fee, status, finish_as, timestamps,
-// error_message, response_msg) capture the per-rung state.
+// / errored). Hedge-level fields (instrument_name, cex_order_type buy/sell,
+// internal_order_id) live on the enclosing CloseHedgingRequest; CexOrderRecord
+// carries only per-rung-snapshot fields.
 message CexOrderRecord {
-  // bucket_idx: Position in EngineConfig.buckets (0-based) — which bucket of
-  // the hedge fan-out this CEX order belongs to.
-  uint32 bucket_idx = 1;
   // rung_idx: Position in Bucket.timeout_ladder (0-based) — which rung this
   // snapshot captures.
-  uint32 rung_idx = 2;
-  // client_order_id: MM-supplied CEX-side idempotency key. Format
-  // `t-<internal_order_id>-<bucket_idx>-<role>` where role is `L` (laddering
-  // limit order) or `M` (taker-fallback market order). Stable across rung
-  // amendments of the same CEX order.
-  string client_order_id = 3;
+  uint32 rung_idx = 1;
   // cex_order_id: CEX-assigned order ID. Empty if placement failed before the
   // CEX returned an id.
-  optional string cex_order_id = 4;
-  // instrument_name: CEX instrument name (e.g. "SUI-USDC").
-  string instrument_name = 5;
-  // cex_order_kind: Buy or sell direction at execution time.
-  bolt.outpost.settlement.v2.SwapType cex_order_kind = 6;
-  // cex_order_type: Limit or market order kind at execution time.
-  bolt.cex.adapter.v1.OrderKind cex_order_type = 7;
+  optional string cex_order_id = 2;
+  // cex_order_kind: Limit or market order kind at execution time.
+  bolt.cex.adapter.v1.OrderKind cex_order_kind = 3;
   // amount: Planned order size at this rung (intent), in base-asset units.
-  bolt.common.numeric.v1.Fraction amount = 8;
+  bolt.common.numeric.v1.Fraction amount = 4;
   // price: Submitted limit price at this rung. Omitted for market orders.
-  optional bolt.common.numeric.v1.Fraction price = 9;
+  optional bolt.common.numeric.v1.Fraction price = 5;
   // filled_in_base: Accumulated base-side fill volume at this rung.
-  bolt.common.numeric.v1.Fraction filled_in_base = 10;
+  bolt.common.numeric.v1.Fraction filled_in_base = 6;
   // filled_in_quote: Accumulated quote-side fill value at this rung.
-  bolt.common.numeric.v1.Fraction filled_in_quote = 11;
-  // avg_deal_price: Volume-weighted average fill price at this rung. Omitted on
+  bolt.common.numeric.v1.Fraction filled_in_quote = 7;
+  // avg_price: Volume-weighted average fill price at this rung. Omitted on
   // zero fill.
-  optional bolt.common.numeric.v1.Fraction avg_deal_price = 12;
+  optional bolt.common.numeric.v1.Fraction avg_price = 8;
   // fee: Accumulated fee deducted at this rung.
-  bolt.common.numeric.v1.Fraction fee = 13;
+  bolt.common.numeric.v1.Fraction fee = 9;
   // fee_currency: Asset in which fee was taken (e.g. "USDT"). Omitted on zero
   // fill.
-  optional string fee_currency = 14;
+  optional string fee_currency = 10;
   // status: In-flight CEX order status at the moment this snapshot was taken
   // (e.g. open, closed, cancelled, partially_filled).
-  bolt.cex.adapter.v1.OrderStatus status = 15;
+  bolt.cex.adapter.v1.OrderStatus status = 11;
   // finish_as: Terminal disposition class of the CEX order. Set on the snapshot
-  // captured at the order's terminal moment; otherwise FINISH_AS_UNSPECIFIED.
-  FinishAs finish_as = 16;
+  // captured at the order's terminal moment; absent on snapshots emitted while
+  // the order is still open.
+  // TODO(BOLT-1833 cleanup): drop the `optional` keyword once the schema only
+  // emits records with a known terminal disposition (every record has a
+  // populated finish_as).
+  optional FinishAs finish_as = 12;
   // rung_started_at: When the order entered this rung (initial place, or amend
   // from prior rung).
-  google.protobuf.Timestamp rung_started_at = 17;
+  google.protobuf.Timestamp rung_started_at = 13;
   // rung_ended_at: When the order left this rung (amended to next, or terminal).
-  google.protobuf.Timestamp rung_ended_at = 18;
+  google.protobuf.Timestamp rung_ended_at = 14;
   // error_message: Per-rung diagnostic; populated if an error was observed at
   // this rung.
-  optional string error_message = 19;
+  optional string error_message = 15;
   // response_msg: Raw CEX response payload (JSON-serialized) at this rung for
   // forensics. Service stores this directly into a JSONB column.
-  optional string response_msg = 20;
+  optional string response_msg = 16;
 }
 
 // CloseHedgingResponse: Result of a CloseHedging call.

--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -10,7 +10,6 @@ import "bolt/outpost/market_ledger/v1/types.proto";
 import "bolt/outpost/settlement/v2/settlement.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 // The PublicMarketLedgerService exposes the same RPCs as MarketLedgerService but with restricted endpoints for external consumption.
@@ -429,8 +428,9 @@ message CexOrderRecord {
   // error_message: Per-rung diagnostic; populated if an error was observed at
   // this rung.
   optional string error_message = 19;
-  // response_msg: Raw CEX response payload at this rung for forensics.
-  optional google.protobuf.Struct response_msg = 20;
+  // response_msg: Raw CEX response payload (JSON-serialized) at this rung for
+  // forensics. Service stores this directly into a JSONB column.
+  optional string response_msg = 20;
 }
 
 // CloseHedgingResponse: Result of a CloseHedging call.

--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -10,6 +10,7 @@ import "bolt/outpost/market_ledger/v1/types.proto";
 import "bolt/outpost/settlement/v2/settlement.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 // The PublicMarketLedgerService exposes the same RPCs as MarketLedgerService but with restricted endpoints for external consumption.
@@ -370,33 +371,66 @@ message CloseHedgingRequest {
   repeated CexOrderRecord cex_order_records = 15;
 }
 
-// CexOrderRecord: A single CEX execution slice produced when a hedge order is decomposed
-// (e.g. across price levels or timeout-ladder steps).
+// CexOrderRecord: Snapshot of a CEX order at one rung of its execution. One row
+// is emitted per (bucket, rung) per CEX order placed in the hedge — at each rung
+// transition (entering a new rung) and at the terminal moment (filled / cancelled
+// / errored). Stable fields (bucket_idx, rung_idx, client_order_id, cex_order_id,
+// instrument_name, cex_order_kind, cex_order_type) repeat across snapshots of the
+// same order; snapshot fields (fills, fee, status, finish_as, timestamps,
+// error_message, response_msg) capture the per-rung state.
 message CexOrderRecord {
-  // cex_order_status: Terminal status — filled, cancelled, partially_filled_cancelled, closed, or error.
-  bolt.cex.adapter.v1.OrderStatus cex_order_status = 1;
-  // cex_order_id: CEX-assigned order ID.
-  optional string cex_order_id = 2;
-  // cex_order_kind: Market or limit order used on CEX.
-  optional bolt.cex.adapter.v1.OrderKind cex_order_kind = 3;
-  // filled_amount: Base amount filled. Required for filled/partially_filled.
-  optional bolt.common.numeric.v1.Fraction filled_amount = 4;
-  // executed_amount: Quote value of fills.
-  optional bolt.common.numeric.v1.Fraction executed_amount = 5;
-  // avg_price: Volume-weighted average fill price.
-  optional bolt.common.numeric.v1.Fraction avg_price = 6;
-  // fee: Fee deducted.
-  optional bolt.common.numeric.v1.Fraction fee = 7;
-  // fee_currency: Asset in which fee was taken.
-  optional string fee_currency = 8;
-  // response_msg: Raw CEX response JSON for audit.
-  optional string response_msg = 9;
-  // market-maker generated UUID
-  string market_maker_uuid = 10;
-  // finished_at: When fill/cancel/error completed on CEX.
-  optional google.protobuf.Timestamp finished_at = 11;
-  // ladder_summary: Summary of the timeout ladder execution for this hedge.
-  optional string ladder_summary = 12;
+  // bucket_idx: Position in EngineConfig.buckets (0-based) — which bucket of
+  // the hedge fan-out this CEX order belongs to.
+  uint32 bucket_idx = 1;
+  // rung_idx: Position in Bucket.timeout_ladder (0-based) — which rung this
+  // snapshot captures.
+  uint32 rung_idx = 2;
+  // client_order_id: MM-supplied CEX-side idempotency key. Format
+  // `t-<internal_order_id>-<bucket_idx>-<role>` where role is `L` (laddering
+  // limit order) or `M` (taker-fallback market order). Stable across rung
+  // amendments of the same CEX order.
+  string client_order_id = 3;
+  // cex_order_id: CEX-assigned order ID. Empty if placement failed before the
+  // CEX returned an id.
+  optional string cex_order_id = 4;
+  // instrument_name: CEX instrument name (e.g. "SUI-USDC").
+  string instrument_name = 5;
+  // cex_order_kind: Buy or sell direction at execution time.
+  bolt.outpost.settlement.v2.SwapType cex_order_kind = 6;
+  // cex_order_type: Limit or market order kind at execution time.
+  bolt.cex.adapter.v1.OrderKind cex_order_type = 7;
+  // amount: Planned order size at this rung (intent), in base-asset units.
+  bolt.common.numeric.v1.Fraction amount = 8;
+  // price: Submitted limit price at this rung. Omitted for market orders.
+  optional bolt.common.numeric.v1.Fraction price = 9;
+  // filled_in_base: Accumulated base-side fill volume at this rung.
+  bolt.common.numeric.v1.Fraction filled_in_base = 10;
+  // filled_in_quote: Accumulated quote-side fill value at this rung.
+  bolt.common.numeric.v1.Fraction filled_in_quote = 11;
+  // avg_deal_price: Volume-weighted average fill price at this rung. Omitted on
+  // zero fill.
+  optional bolt.common.numeric.v1.Fraction avg_deal_price = 12;
+  // fee: Accumulated fee deducted at this rung.
+  bolt.common.numeric.v1.Fraction fee = 13;
+  // fee_currency: Asset in which fee was taken (e.g. "USDT"). Omitted on zero
+  // fill.
+  optional string fee_currency = 14;
+  // status: In-flight CEX order status at the moment this snapshot was taken
+  // (e.g. open, closed, cancelled, partially_filled).
+  bolt.cex.adapter.v1.OrderStatus status = 15;
+  // finish_as: Terminal disposition class of the CEX order. Set on the snapshot
+  // captured at the order's terminal moment; otherwise FINISH_AS_UNSPECIFIED.
+  FinishAs finish_as = 16;
+  // rung_started_at: When the order entered this rung (initial place, or amend
+  // from prior rung).
+  google.protobuf.Timestamp rung_started_at = 17;
+  // rung_ended_at: When the order left this rung (amended to next, or terminal).
+  google.protobuf.Timestamp rung_ended_at = 18;
+  // error_message: Per-rung diagnostic; populated if an error was observed at
+  // this rung.
+  optional string error_message = 19;
+  // response_msg: Raw CEX response payload at this rung for forensics.
+  optional google.protobuf.Struct response_msg = 20;
 }
 
 // CloseHedgingResponse: Result of a CloseHedging call.

--- a/bolt/outpost/market_ledger/v1/types.proto
+++ b/bolt/outpost/market_ledger/v1/types.proto
@@ -53,3 +53,26 @@ enum ExecutionStrategy {
   // EXECUTION_STRATEGY_TAKER: Market/taker order for immediate fill.
   EXECUTION_STRATEGY_TAKER = 6;
 }
+
+// FinishAs: Terminal disposition class of a CEX order at the rung where it
+// settled. Distinct from `bolt.cex.adapter.v1.OrderStatus`, which models the
+// in-flight lifecycle state (open / closed / cancelled / etc.). Default zero
+// value (`FINISH_AS_UNSPECIFIED`) means the order has not yet finished — used
+// on snapshots emitted while the order is still open.
+enum FinishAs {
+  // FINISH_AS_UNSPECIFIED: Order has not finished yet (still open or
+  // disposition not yet known). Default zero value.
+  FINISH_AS_UNSPECIFIED = 0;
+  // FINISH_AS_FILLED: Order filled completely.
+  FINISH_AS_FILLED = 1;
+  // FINISH_AS_CANCELLED: Order cancelled (no fill or partial fill before
+  // cancel).
+  FINISH_AS_CANCELLED = 2;
+  // FINISH_AS_IOC: Order completed via immediate-or-cancel; unfilled portion
+  // auto-cancelled.
+  FINISH_AS_IOC = 3;
+  // FINISH_AS_STP: Order cancelled by CEX self-trade prevention.
+  FINISH_AS_STP = 4;
+  // FINISH_AS_ERROR: Order finished with a CEX-side error.
+  FINISH_AS_ERROR = 5;
+}


### PR DESCRIPTION
## Summary
- Reshape `CexOrderRecord` to per-rung snapshot (breaking → `Buf Skip Breaking` label required)
- Add `FinishAs` enum in `types.proto`
- Add `instrument_name` to `CloseHedgingRequest` (hedge-level, MM-supplied)
- `CloseHedgingRequest.cex_order_type` (SwapType buy/sell) is now the **only** carrier of hedge side — no per-record duplicate

## CexOrderRecord fields
- **ADDED** `rung_idx` (1) — rung position in `Bucket.timeout_ladder` — IT-14 AC4, § 7 addressing
- **MOVED** `cex_order_id` (tag 2 → 2) — CEX-assigned id; empty if pre-submit failure — IT-05, IT-04 AC4
- **CHANGED** `cex_order_kind` (3) — was `OrderKind` (limit/market) at tag 3; type unchanged but tag/cardinality reshuffled in this PR — IT-05
- **ADDED** `amount` (4) — planned order size at rung (intent) — IT-05
- **ADDED** `price` (5) — submitted limit price; absent for market — IT-05
- **RENAMED** `filled_in_base` (6) — was `filled_amount` (tag 4) — accumulated base-side fill (CEX-reported) — IT-13 (drives residual restore)
- **RENAMED** `filled_in_quote` (7) — was `executed_amount` (tag 5) — accumulated quote-side fill — IT-05
- **MOVED** `avg_price` (tag 6 → 8) — VWAP at rung; absent on zero fill — IT-05
- **MOVED** `fee` (tag 7 → 9) — accumulated fee at rung — IT-05
- **MOVED** `fee_currency` (tag 8 → 10) — fee asset; absent on zero fill — FR-017 (WARN on cross-record divergence)
- **RENAMED** `status` (11) — was `cex_order_status` (tag 1) — in-flight CEX `OrderStatus` at snapshot — IT-05
- **ADDED** `finish_as` (12) — terminal disposition (`optional FinishAs`); absent while open. TODO(BOLT-1833 cleanup): drop `optional` once non-terminal records aren't emitted — IT-05, IT-07
- **ADDED** `rung_started_at` (13) — order entered rung (initial place / amend) — IT-05
- **MOVED** `rung_ended_at` (tag 11 → 14) — was legacy `finished_at` (Timestamp) — order left rung (amend or terminal) — IT-05
- **ADDED** `error_message` (15) — per-rung diagnostic — IT-05 (placement-failure case)
- **MOVED** `response_msg` (tag 9 → 16) — raw CEX response (JSON string), forensics; service writes directly to JSONB column — IT-05
- **MOVED** `ladder_summary` (tag 12 → 17) — summary of the timeout ladder execution for this hedge — IT-05

## Removed from CexOrderRecord
- **REMOVED** `market_maker_uuid` (was tag 10) — replaced conceptually by `client_order_id`, which is itself now derivable per-bucket on the MM side and not on the wire
- **REMOVED** `bucket_idx` — bucket is hedge-level execution detail, not part of the per-record snapshot wire contract
- **REMOVED** `client_order_id` — derivable on the MM side; not needed on the persistence wire
- **REMOVED** per-record buy/sell field (`cex_order_kind` / `SwapType`) — single side per hedge lives on `CloseHedgingRequest.cex_order_type`
- **REMOVED** `instrument_name` (per-record) — hedge-level value, lifted to `CloseHedgingRequest.instrument_name`

## CloseHedgingRequest changes
- **ADDED** `instrument_name` (16) — MM-supplied; canonical hedge-level value, shared by every record in `cex_order_records`

## Linear
- [BOLT-1833 — Position Engine: Multi-Laddered Concurrent Hedging](https://linear.app/philabsxyz/issue/BOLT-1833/position-engine-multi-laddered-concurrent-hedging)
