### PR TITLE
feat(BOLT-1982): add LEDGER_STATUS_ABANDONED and AssetConfig.in_progress_expiry

### DIFF
--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -123,6 +123,9 @@ message AssetConfig {
   // dust_threshold: Below this absolute delta, TIME triggers are suppressed (dust filter).
   // Sign-agnostic; gates TIME only — AMOUNT fires regardless. Set to 0 to disable.
   bolt.common.numeric.v1.Fraction dust_threshold = 3;
+  // in_progress_expiry: How long an in_progress ledger may live before being marked
+  // abandoned at subscribe time. Must be > 0.
+  google.protobuf.Duration in_progress_expiry = 4;
 }
 
 // SwapEvent: A single swap event ingested from the on-chain pool.

--- a/bolt/outpost/market_ledger/v1/types.proto
+++ b/bolt/outpost/market_ledger/v1/types.proto
@@ -22,6 +22,9 @@ enum LedgerStatus {
   LEDGER_STATUS_CLOSED = 2;
   // LEDGER_STATUS_IN_PROGRESS: Created by service-side trigger evaluation — snapshot of hedged delta/vwap.
   LEDGER_STATUS_IN_PROGRESS = 3;
+  // LEDGER_STATUS_ABANDONED: in_progress ledger exceeded in_progress_expiry at subscribe time;
+  // the MM never placed the hedge (service or MM was down). Delta is written off; hedge_order left unchanged.
+  LEDGER_STATUS_ABANDONED = 4;
 }
 
 // TriggerReason: Why a hedge trigger fired. Encodes the breached condition only —


### PR DESCRIPTION
## Summary

https://linear.app/philabsxyz/issue/BOLT-1982/do-not-hedge-ledgers-that-are-older-than-x-secs-when-the-market-maker

- Add `LEDGER_STATUS_ABANDONED = 4` to `LedgerStatus` enum — marks in_progress ledgers that exceeded the per-asset expiry at subscribe time (MM never placed the hedge)
- Add `in_progress_expiry` (field 4, `google.protobuf.Duration`) to `AssetConfig` — configures how long an in_progress ledger may live before being abandoned

## Context
BOLT-1982: when the MM reconnects and subscribes for in-progress ledgers, the ledger service must not replay hedges that are older than a configurable threshold. Stale ledgers are marked `abandoned` in the DB and excluded from the catch-up replay. Their delta is written off.