### PR TITLE
feat: update proto to handle new rung configs

### DIFF
--- a/bolt/outpost/market_ledger/v2/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v2/market_ledger.proto
@@ -26,13 +26,12 @@ message MarketStateEntry {
   MarketStateStrategy strategy = 2;
 }
 
-// TimeoutStep: One rung of the hedge timeout ladder. `strategies` must
-// contain exactly three entries (FAVORABLE, NEUTRAL, ADVERSE); the MM
-// selects by `state` using gap_bps vs EngineConfig.gap_threshold_bps.
+// TimeoutStep: One rung of the hedge timeout ladder. `strategies` size is
+// 1 (NEUTRAL only) or 3 (FAVORABLE+NEUTRAL+ADVERSE, all unique).
 message TimeoutStep {
   // delay: Wait before escalating to the next rung.
   google.protobuf.Duration delay = 1;
-  // strategies: (state, strategy) entries; exactly one per MarketState.
+  // strategies: (state, strategy) entries; size 1 (NEUTRAL) or 3 (unique).
   repeated MarketStateEntry strategies = 2;
 }
 

--- a/bolt/outpost/market_ledger/v2/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v2/market_ledger.proto
@@ -10,15 +10,30 @@ import "bolt/outpost/market_ledger/v2/types.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-// TimeoutStep: One rung of the hedge timeout ladder. Position within its enclosing
-// Bucket.timeout_ladder is the rung_idx (no field carried explicitly).
+// MarketStateStrategy: Execution strategy + spread for one market state.
+message MarketStateStrategy {
+  // strategy: Execution strategy.
+  ExecutionStrategy strategy = 1;
+  // spread_bps: Spread in basis points applied to the limit price.
+  optional bolt.common.numeric.v2.Fraction spread_bps = 2;
+}
+
+// MarketStateEntry: (state, strategy) pair; enum-keyed-map shim for proto3.
+message MarketStateEntry {
+  // state: Market state this entry applies to.
+  MarketState state = 1;
+  // strategy: Strategy to apply when `state` matches.
+  MarketStateStrategy strategy = 2;
+}
+
+// TimeoutStep: One rung of the hedge timeout ladder. `strategies` must
+// contain exactly three entries (FAVORABLE, NEUTRAL, ADVERSE); the MM
+// selects by `state` using gap_bps vs EngineConfig.gap_threshold_bps.
 message TimeoutStep {
-  // delay: How long to wait before escalating to this strategy.
+  // delay: Wait before escalating to the next rung.
   google.protobuf.Duration delay = 1;
-  // strategy: Execution strategy to use at this timeout rung.
-  ExecutionStrategy strategy = 2;
-  // spread_bps: Optional spread in basis points applied to this rung's limit price.
-  optional bolt.common.numeric.v2.Fraction spread_bps = 3;
+  // strategies: (state, strategy) entries; exactly one per MarketState.
+  repeated MarketStateEntry strategies = 2;
 }
 
 // Bucket: A single ladder bucket. Splits the hedge into a percentage-sized slice
@@ -44,6 +59,9 @@ message EngineConfig {
   // timeout_ladder over its percent_bps slice of the hedge. Position in this
   // list is the bucket_idx.
   repeated Bucket buckets = 4;
+  // gap_threshold_bps: |gap| in bps between gate mid and residual VWAP at
+  // which neutral flips to favorable / adverse. Zero = always non-neutral.
+  bolt.common.numeric.v2.Fraction gap_threshold_bps = 5;
 }
 
 // AssetConfig: Per-asset, sign-agnostic policy. Inventory-at-risk duration and

--- a/bolt/outpost/market_ledger/v2/types.proto
+++ b/bolt/outpost/market_ledger/v2/types.proto
@@ -51,6 +51,21 @@ enum TriggerReason {
   TRIGGER_REASON_TIME = 2;
 }
 
+// MarketState: Possible market-states at rung-assessment time.
+enum MarketState {
+  // MARKET_STATE_UNSPECIFIED: Default zero value; must not be used explicitly.
+  MARKET_STATE_UNSPECIFIED = 0;
+  // MARKET_STATE_FAVORABLE: gap_bps >= gap_threshold_bps — the gate has moved
+  // in the MM's favor relative to residual VWAP.
+  MARKET_STATE_FAVORABLE = 1;
+  // MARKET_STATE_NEUTRAL: |gap_bps| < gap_threshold_bps — book is roughly at
+  // VWAP.
+  MARKET_STATE_NEUTRAL = 2;
+  // MARKET_STATE_ADVERSE: gap_bps < -gap_threshold_bps — the gate has moved
+  // against the MM.
+  MARKET_STATE_ADVERSE = 3;
+}
+
 // ExecutionStrategy: Pricing and execution strategy for a single TimeoutStep ladder rung.
 enum ExecutionStrategy {
   // EXECUTION_STRATEGY_UNSPECIFIED: Default zero value; must not be used explicitly.


### PR DESCRIPTION
This PR is part of a larger set for Bolt-1999. It allows each rung to have sub-configurations depending on market conditions