### PR TITLE
feat(settlement): BOLT-2143 add STALE_PRICE and QUOTE_NOT_TRADING rebalance statuses

### DIFF
--- a/bolt/outpost/settlement/v2/settlement.proto
+++ b/bolt/outpost/settlement/v2/settlement.proto
@@ -404,6 +404,10 @@ enum RebalanceStatusType {
   REBALANCE_STATUS_TYPE_ZERO_BASE_INPUT_AMOUNT = 10;
   // Pool paused error.
   REBALANCE_STATUS_TYPE_POOL_PAUSED = 11;
+  // Oracle price for the pair is missing or expired; swap cannot be priced.
+  REBALANCE_STATUS_TYPE_STALE_PRICE = 12;
+  // Quote asset is configured but toggled out of trading; swap cannot execute.
+  REBALANCE_STATUS_TYPE_QUOTE_NOT_TRADING = 13;
 }
 
 // RebalanceSwapSellRequest: Sells base tokens and sends quote proceeds and base surplus to their


### PR DESCRIPTION
Adds REBALANCE_STATUS_TYPE_STALE_PRICE (12) and REBALANCE_STATUS_TYPE_QUOTE_NOT_TRADING (13) so the market_maker rebalance_swap_sell contract can report stale-oracle-price and non-trading-quote conditions as graceful no-op statuses instead of aborting (BOLT-2143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)