### PR TITLE
feat: Add FLASH swap type to SwapType enum

### DIFF
--- a/bolt/outpost/settlement/v2/settlement.proto
+++ b/bolt/outpost/settlement/v2/settlement.proto
@@ -202,7 +202,7 @@ enum SwapType {
   SWAP_TYPE_BUY = 1;
   //  SWAP_TYPE_SELL: Swap sell type.
   SWAP_TYPE_SELL = 2;
-  // SWAP_TYPE_FLASH: Flash swap sell type, where user sells and buys in the same transaction.
+  //  SWAP_TYPE_FLASH: Flash swap type, where a user sells and buys in the same transaction.
   SWAP_TYPE_FLASH = 3;
 }
 

--- a/bolt/outpost/settlement/v2/settlement.proto
+++ b/bolt/outpost/settlement/v2/settlement.proto
@@ -202,6 +202,8 @@ enum SwapType {
   SWAP_TYPE_BUY = 1;
   //  SWAP_TYPE_SELL: Swap sell type.
   SWAP_TYPE_SELL = 2;
+  // SWAP_TYPE_FLASH: Flash swap sell type, where user sells and buys in the same transaction.
+  SWAP_TYPE_FLASH = 3;
 }
 
 // Pool: Description of the single liquidity pool.


### PR DESCRIPTION
Introduce SWAP_TYPE_FLASH = 3 in bolt/outpost/settlement/v2/settlement.proto to represent a flash swap (user sells and buys within the same transaction). This allows the system to distinguish flash swaps from standard buy/sell swap types.