### PR TITLE
ci: upgrade actions/checkout to v7 across all workflows

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         sparse-checkout: ${{ inputs.sparse-checkout }}
 

--- a/.github/workflows/buf-registry.yaml
+++ b/.github/workflows/buf-registry.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Publish to Buf Schema Registry
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -11,7 +11,7 @@ jobs:
   buf:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
         with:
           push: false


### PR DESCRIPTION
## Summary
Updates the `actions/checkout` action from v4 to v7 across all GitHub Actions workflows and custom actions.

## Changes
- Updated `.github/actions/checkout/action.yml` to use `actions/checkout@v7`
- Updated `.github/workflows/buf-registry.yaml` to use `actions/checkout@v7`
- Updated `.github/workflows/buf.yaml` to use `actions/checkout@v7`

## Details
This upgrade brings the latest improvements and security updates from the `actions/checkout` action. All three locations where the checkout action is referenced have been synchronized to the same version.

https://claude.ai/code/session_016ZVVSLDCEvVet51wTRMUeF