### PR TITLE
feat: support for various market order types

### DIFF
--- a/bolt/outpost/market_ledger/v2/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v2/market_ledger.proto
@@ -39,6 +39,9 @@ message TimeoutStep {
   google.protobuf.Duration delay = 1;
   // strategies: (state, strategy, delay) entries; size 1 (NEUTRAL) or 3 (unique).
   repeated MarketStateEntry strategies = 2;
+  // cex_order_strategy: Venue-agnostic time-in-force applied to orders placed at
+  // this rung. When absent, defaults to CEX_ORDER_STRATEGY_GTC.
+  optional CexOrderStrategy cex_order_strategy = 3;
 }
 
 // Bucket: A single ladder bucket. Splits the hedge into a percentage-sized slice

--- a/bolt/outpost/market_ledger/v2/types.proto
+++ b/bolt/outpost/market_ledger/v2/types.proto
@@ -84,6 +84,18 @@ enum ExecutionStrategy {
   EXECUTION_STRATEGY_TAKER = 6;
 }
 
+// CexOrderStrategy: Venue-agnostic time-in-force strategy for CEX limit orders.
+enum CexOrderStrategy {
+  // CEX_ORDER_STRATEGY_UNSPECIFIED: No strategy was explicitly supplied.
+  CEX_ORDER_STRATEGY_UNSPECIFIED = 0;
+  // CEX_ORDER_STRATEGY_GTC: Keep the order open until filled or cancelled.
+  CEX_ORDER_STRATEGY_GTC = 1;
+  // CEX_ORDER_STRATEGY_POC: Post-only; the order must not execute immediately as a taker.
+  CEX_ORDER_STRATEGY_POC = 2;
+  // CEX_ORDER_STRATEGY_IOC: Execute immediately and cancel any unfilled remainder.
+  CEX_ORDER_STRATEGY_IOC = 3;
+}
+
 // FinishAs: Terminal disposition class of a CEX order at the rung where it
 // settled. Distinct from `bolt.cex.adapter.v1.OrderStatus`, which models the
 // in-flight lifecycle state (open / closed / cancelled / etc.). Default zero


### PR DESCRIPTION
Add configurable order type to each bucket. Downstream will enforce correct default behaviour.

[FR-01](https://linear.app/philabsxyz/issue/BOLT-2261/support-poc-post-only-time-in-force-on-hedge-rung-orders#fr-01-cex-order-strategy-is-a-cb6ab658)