### PR TITLE
feat: add inventory_event_id and swap_ids to mm Inventory

### DIFF
--- a/bolt/mm/v1/inventory.proto
+++ b/bolt/mm/v1/inventory.proto
@@ -106,6 +106,16 @@ message Inventory {
   // configured direction (LONG, SHORT). Empty when no engine config is
   // currently loaded for the asset.
   repeated NettingThreshold netting_thresholds = 9;
+
+  // inventory_event_id: Unique id of this emitted frame (UUID), for
+  // cross-component traceability. Distinct from `id`, which tracks the
+  // ledger row and repeats across frames.
+  string inventory_event_id = 10;
+
+  // swap_ids: swap_id of each swap in the batch that produced this frame.
+  // Empty on non-swap frames (HEDGE_TRIGGER, TIME_TRIGGER,
+  // CLOSE_HEDGING_RESTORE, snapshot).
+  repeated string swap_ids = 11;
 }
 
 // NettingThreshold: |delta| threshold at which the netting engine fires a


### PR DESCRIPTION
- Add `inventory_event_id` (unique UUID per emitted frame) and `swap_ids` (swap_id of each swap in the producing batch; empty on non-swap frames) to `bolt.mm.v1.Inventory`
- Additive only — field numbers 10/11; `id` and `trigger_reason` unchanged
- https://linear.app/philabsxyz/issue/BOLT-2290/add-ledger-event-id-or-swap-ids-to-the-inventory-updates