### PR TITLE
chore: correct documented client_order_id format on CexOrderRecord

### DIFF
--- a/bolt/outpost/market_ledger/v1/market_ledger.proto
+++ b/bolt/outpost/market_ledger/v1/market_ledger.proto
@@ -398,7 +398,7 @@ message CexOrderRecord {
   uint32 bucket_idx = 1;
   // rung_idx: Position in Bucket.timeout_ladder (0-based) — which rung this order was placed at.
   uint32 rung_idx = 2;
-  // client_order_id: Client-supplied idempotency key, formatted "t-<internal_order_id>-<bucket_idx>".
+  // client_order_id: Client-supplied idempotency key, formatted "t-<hedge_id>-<bucket_idx>-<L|M>".
   string client_order_id = 3;
   // cex_order_id: CEX-assigned order ID. Empty if placement failed before the CEX returned an id.
   string cex_order_id = 4;

--- a/bolt/outpost/market_ledger/v2/private_market_ledger.proto
+++ b/bolt/outpost/market_ledger/v2/private_market_ledger.proto
@@ -59,7 +59,7 @@ message CexOrderRecord {
   uint32 bucket_idx = 1;
   // rung_idx: Position in Bucket.timeout_ladder (0-based) — which rung this order was placed at.
   uint32 rung_idx = 2;
-  // client_order_id: Client-supplied idempotency key, formatted "t-<internal_order_id>-<bucket_idx>".
+  // client_order_id: Client-supplied idempotency key, formatted "t-<hedge_id>-<bucket_idx>-<L|M>".
   string client_order_id = 3;
   // cex_order_id: CEX-assigned order ID. Empty if placement failed before the CEX returned an id.
   string cex_order_id = 4;


### PR DESCRIPTION
- Docs claimed `t-<internal_order_id>-<bucket_idx>`; the market maker sends `t-<hedge_id>-<bucket_idx>-<L|M>`
- Misleads anyone joining ledger records back to a hedge — the UUID never appears in the client order id
- Corrected in both `v2/private_market_ledger.proto` and `v1/market_ledger.proto`
- Comment-only: no field, tag, or wire change
- Format verified against the current implementation and its history; the documented shape was never in use